### PR TITLE
Fixes crash when adding duplicated chunks to bundles and adds DisplayName to FBX Export Window.

### DIFF
--- a/Plugins/BundleEditorPlugin/BundleEditor.cs
+++ b/Plugins/BundleEditorPlugin/BundleEditor.cs
@@ -44,7 +44,7 @@ namespace BundleEditPlugin
                     if (lod.ChunkId != Guid.Empty)
                     {
                         ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
-                        if (chunkEntry != null && chunkEntry.SuperBundles.Count == 0)
+                        if (chunkEntry != null && chunkEntry.SuperBundles.Count == 0 && chunkEntry.AddedSuperBundles.Count == 0)
                         {
                             chunkEntry.AddedBundles.Remove(App.AssetManager.GetBundleId(bentry));
                             resEntry.LinkAsset(chunkEntry);
@@ -232,7 +232,7 @@ namespace BundleEditPlugin
                     if (lod.ChunkId != Guid.Empty)
                     {
                         ChunkAssetEntry chunkEntry = App.AssetManager.GetChunkEntry(lod.ChunkId);
-                        if (chunkEntry != null && chunkEntry.SuperBundles.Count == 0)
+                        if (chunkEntry != null && chunkEntry.SuperBundles.Count == 0 && chunkEntry.AddedSuperBundles.Count == 0)
                         {
                             chunkEntry.AddToBundle(App.AssetManager.GetBundleId(bentry));
                             resEntry.LinkAsset(chunkEntry);
@@ -314,9 +314,9 @@ namespace BundleEditPlugin
         }
     }
 
-    public class TextureExtension : AddToBundleExtension
+    public class TextureBaseExtension : AddToBundleExtension
     {
-        public override string AssetType => "TextureAsset";
+        public override string AssetType => "TextureBaseAsset";
         public override void AddToBundle(EbxAssetEntry entry, BundleEntry bentry)
         {
             base.AddToBundle(entry, bentry);
@@ -338,9 +338,9 @@ namespace BundleEditPlugin
         }
     }
 
-    public class MovieTexture2Extension : AddToBundleExtension
+    public class MovieTextureExtension : AddToBundleExtension
     {
-        public override string AssetType => "MovieTexture2Asset";
+        public override string AssetType => "MovieTextureBaseAsset";
         public override void AddToBundle(EbxAssetEntry entry, BundleEntry bentry)
         {
             base.AddToBundle(entry, bentry);

--- a/Plugins/MeshSetPlugin/MeshAssetDefinition.cs
+++ b/Plugins/MeshSetPlugin/MeshAssetDefinition.cs
@@ -39,10 +39,13 @@ namespace MeshSetPlugin
 
         public MeshExportScale Scale { get; set; }
 
+        [DisplayName("Flatten Hierarchy (Blender)")]
         public bool FlattenHierarchy { get; set; }
 
+        [DisplayName("Export Single LOD")]
         public bool ExportSingleLod { get; set; }
 
+        [DisplayName("Export Additional Meshes")]
         public bool ExportAdditionalMeshes { get; set; }
     }
 


### PR DESCRIPTION
Also includes:
[BundleEditorPlugin] Minor edits to match 1.0.6.3
[MeshSetPlugin] DisplayName to match 1.0.6.3